### PR TITLE
Winning logic adjusted checking with multiplayer-support

### DIFF
--- a/server/Stage.cpp
+++ b/server/Stage.cpp
@@ -193,6 +193,7 @@ void Stage::managePortals(Chell* chell, std::string id) {
 }
 
 void Stage::step() {
+    if (end_of_game) return;
     end_of_game = true;
     for (auto i = chells.begin(); i != chells.end(); i++) {
         if (i->second->isDead()) {
@@ -210,6 +211,7 @@ void Stage::step() {
                 world->destroyBody(i->second->getBody());
             }
         }
+        return;
     }
     for (auto i = blue_shots.begin(); i != blue_shots.end(); i++) {
         if (i->second->isDead()) {

--- a/server/StageManager.cpp
+++ b/server/StageManager.cpp
@@ -36,7 +36,7 @@ void StageManager::run() {
 
 void StageManager::handleEvent(UserEvent &userEvent,
         Chell *chell) {
-    if (chell == nullptr) return;
+    if (chell == nullptr || chell->hasWon()) return;
     std::string chell_id = userEvent.getUserId();
     int eventTypeCode = userEvent.getEventType();
     switch (eventTypeCode) {


### PR DESCRIPTION
I thought that when one player reaches the cake it implies for the whole team to win the game. But reading again i found out that everyone had to reach the cake, so i fixed it