### PR TITLE
Fixed a bug where the camera would go out of bounds

### DIFF
--- a/client/views/Camera.cpp
+++ b/client/views/Camera.cpp
@@ -9,8 +9,10 @@ Camera::Camera(int screenWidth, int screenHeight,
         int levelWidth, int levelHeight) :
         levelWidth(levelWidth),
         levelHeight(levelHeight) {
-       cameraRect.w = screenWidth;
-       cameraRect.h = screenHeight;
+        // If the level is smaller than the camera in some way,
+        // then we'll set the camera size according to the level size.
+       cameraRect.w = screenWidth <= levelWidth ? screenWidth : levelWidth;
+       cameraRect.h = screenHeight <= levelHeight ? screenHeight : levelHeight;
        cameraRect.x = 0;
        cameraRect.y = 0;
 }


### PR DESCRIPTION
Found a weird bug where the camera would go out of bounds if the level width/height was smaller than the screen (camera) width/height.